### PR TITLE
Mark koreader-tategumi as third-party fork, move to end of Official Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@
 ## Official Resources
 
 - [koreader/koreader](https://github.com/koreader/koreader) - The main KOReader repository. Releases, issues, and source code.
-- [m-tky/koreader-tategumi](https://github.com/m-tky/koreader-tategumi) - KOReader fork for Japanese vertical writing (`writing-mode: vertical-rl`) in EPUBs with ruby, OTA updates, and RTL page order detection.
 - [koreader/contrib](https://github.com/koreader/contrib) - Official collection of non-official community plugins and scripts maintained under the KOReader org.
 - [KOReader Wiki](https://github.com/koreader/koreader/wiki) - Official wiki with installation guides, user patches documentation, and device-specific notes.
 - [KOReader Website](https://koreader.rocks) - Official website with download links and news.
@@ -49,6 +48,7 @@
 - [koreader/android-luajit-launcher](https://github.com/koreader/android-luajit-launcher) - Android launcher for KOReader's LuaJIT-based runtime.
 - [KoboUSBMS](https://github.com/koreader/KoboUSBMS) - Standalone mass storage mode for Kobo devices.
 - [koreader/translations](https://github.com/koreader/koreader-translations) - Community-contributed translations for KOReader.
+- [m-tky/koreader-tategumi](https://github.com/m-tky/koreader-tategumi) - **Third-party fork** (not officially affiliated) adding `writing-mode: vertical-rl` rendering for Japanese vertical EPUBs with ruby, OTA updates, and RTL page order detection.
 
 ---
 


### PR DESCRIPTION
Thanks for accepting #22 and adding koreader-tategumi to the list!

I'm a bit worried about the current placement, though: koreader-tategumi is a personal third-party fork (not affiliated with or endorsed by the official KOReader project), and having it directly under the main `koreader/koreader` entry in "Official Resources" could give readers — and the upstream maintainers — the wrong impression.

This PR keeps it in the same section but moves it to the end of the list and adds a "Third-party fork (not officially affiliated)" prefix in the description, so the affiliation is clear without losing the visibility.

Happy to move it to another section if you'd prefer; I just couldn't find an existing one that fit a fork cleanly.