### PR TITLE
Add backlog.koplugin: per-article read tracking for anthology EPUBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@
 
 *Track your reading habits, set goals, and review your statistics.*
 
+- [backlog.koplugin](https://github.com/cdrso/backlog.koplugin) - Per-article read tracking for anthology EPUBs (collections of standalone, interlinked essays): shows which pieces you've read, jumps to the next unread, and auto-marks each as you finish.
 - [KoInsight](https://github.com/GeorgeSG/KoInsight) - Web-based dashboard with charts and insights from your KOReader reading statistics. Self-hostable with Docker. ⭐ 452+
 - [readmastery.koplugin](https://github.com/Lalocaballero/readmastery.koplugin) - Transforms your reading into an RPG-style adventure — earn XP, level up, maintain streaks, and unlock achievements as you read.
 - [koreader-stats-exporter](https://github.com/bbb651/koreader-stats-exporter) - Export KOReader reading statistics to various formats for external analysis.


### PR DESCRIPTION
## What are you adding/changing?

Adding **backlog.koplugin** to the *Reading Tracking & Goals* category. It tracks which articles/chapters you've read within a single anthology EPUB — a book that's really a collection of standalone, interlinked, non-chronological essays read in any order. It adds an articles list (read / unread / currently-reading) with a running count, a jump-to-next-unread action, and automatic read-marking as you finish each piece. Read state is stored per book in KOReader's sidecar, keyed by each article's xpointer so it survives re-pagination.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/jannick-holm/awesome-koreader/blob/main/CONTRIBUTING.md) guide
- [x] The project is publicly accessible with a working link
- [x] The project has a README with installation instructions
- [x] It is compatible with a recent version of KOReader (or the compatible version is noted in my entry)
- [x] My entry follows the correct format: `- [name](url) - One-sentence description.`
- [x] I placed the entry in the most appropriate existing category
- [x] The description starts with a capital letter and ends with a period
- [x] I am not adding a duplicate of an existing entry

## Self-promotion disclosure

- [x] I am the author or maintainer of the project I'm adding.

## Additional context

Tested on a real Kindle and the KOReader desktop emulator. MIT-licensed; no hardcoded paths (state goes through KOReader's `doc_settings` / `G_reader_settings`, so it works across Kindle/Kobo/Android); `_meta.lua` provides `fullname` + `description`. The repo carries the `koreader-plugin` topic, so it's also installable in-device via the App Store plugin. Entry placed alphabetically at the top of *Reading Tracking & Goals*.