### PR TITLE
Add kindlebtcontroller.koplugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ server and more. ⭐ 3,6K+
 
 ### Kindle
 
+- [kindlebtcontroller.koplugin](https://github.com/finlater/kindlebtcontroller.koplugin) - Control page turns, brightness, chapter navigation, and other KOReader actions on supported Kindles with Bluetooth HID gamepads and remotes. ⭐ 72+
 - [ProjectTitle](https://github.com/joshuacant/ProjectTitle) - Added Kindle support in v2025.04+.
 
 ### reMarkable


### PR DESCRIPTION
## What are you adding/changing?

Adds `kindlebtcontroller.koplugin` to the Device-Specific → Kindle section. The plugin lets supported Kindle models use Bluetooth HID gamepads and remotes for page turns, brightness adjustment, chapter navigation, and other KOReader actions.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] The project is publicly accessible with a working link
- [x] The project has a README with installation instructions
- [x] It is compatible with a recent version of KOReader (or the compatible version is noted in my entry)
- [x] My entry follows the correct format: `- [name](url) - One-sentence description.`
- [x] I placed the entry in the most appropriate existing category
- [x] The description starts with a capital letter and ends with a period
- [x] I am not adding a duplicate of an existing entry

## Self-promotion disclosure

- [x] I am the author or maintainer of the project I'm adding *(if yes, that's fine — just check the box)*

## Additional context

I maintain the plugin. It has been verified on Kindle 2024, Kindle Paperwhite 11, and Kindle Paperwhite 12. It supports Classic BR/EDR Bluetooth HID controllers, not BLE devices; the project README documents the required pairing setup and warns against using it on unsupported older Kindle models.

Validation: `git diff --check` passed, and the project link returned HTTP 200.
