### PR TITLE
Add kindle-quran to Utilities & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ server and more. ⭐ 3,6K+
 
 *Miscellaneous plugins that add useful functionality.*
 
+- [kindle-quran](https://github.com/alfajrd/kindle-quran) - Read the Qur'an in Uthmani Arabic beside an English translation, fully offline, with dictionary lookup on the translation.
 - [webbrowser.koplugin](https://github.com/omer-faruq/webbrowser.koplugin) - Text-based web browser inside KOReader. ⭐ 58+
 - [localsend.koplugin](https://github.com/kaikozlov/localsend.koplugin) - Wireless local file transfer. ⭐ 104+
 


### PR DESCRIPTION
Adds [kindle-quran](https://github.com/alfajrd/kindle-quran) to **Utilities & Tools**.

A KOReader plugin for reading the Qur'an: Uthmani Arabic beside an English translation in a two-column layout, entirely offline. Surah and juz navigation, reference jump, bookmarks, independent typography per script, and hold-a-word dictionary lookup in the translation column.

**Disclosure: I'm the author.** CONTRIBUTING.md says self-promotion is fine if disclosed, so — disclosed.

Against the checklist:

- **Publicly accessible** — https://github.com/alfajrd/kindle-quran
- **README with description and install instructions** — yes, including a step-by-step on-device checklist
- **Works with a recent KOReader** — tested on a Kindle Paperwhite 11; requires 2024.12+ for `use_xtext` shaping, noted in the README
- **Canonical source, not a mirror or fork** — yes
- **Not abandoned** — first release [v1.0.0](https://github.com/alfajrd/kindle-quran/releases/tag/v1.0.0) published this week

One note on placement: the section's two existing entries aren't in alphabetical order (`webbrowser`, then `localsend`). CONTRIBUTING asks for alphabetical, so I put the new entry first, where it sorts among the three — but I didn't reorder your existing lines, to keep this to a one-line diff. Happy to sort the whole section instead if you'd prefer, or to move the entry somewhere else entirely: **Utilities & Tools** seemed the most honest fit since there's no category for reading a specific text, but it's your list and I'll follow your call.

I left the star count off deliberately — the repo is new enough that a number would be noise.
