### PR TITLE
Add Crossbill to the desktop companions and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ These are documented on the [User Patches Wiki](https://github.com/koreader/kore
 
 *Applications that run on your PC/Mac to complement your KOReader experience.*
 
+- [Crossbill](https://github.com/Crossbill-App/crossbill-web) - Self-hosted web reading companion tool for guided active reading practice, managing highlights, notes, flashcards and more.
 - [KoInsight](https://github.com/GeorgeSG/KoInsight) - Web dashboard for reading stats visualization, highlights management, and sync server. ⭐ 452+
 - [KoHighlights](https://github.com/noembryo/KoHighlights) - Desktop GUI for browsing, filtering, and exporting highlights and notes from KOReader sidecar files.
 - [koreader-calibre-plugin](https://github.com/harmtemolder/koreader-calibre-plugin) - Calibre plugin to sync reading progress, ratings, and annotations from KOReader `.sdr` metadata folders.


### PR DESCRIPTION
## What are you adding/changing?
Crossbill is a self hosted reading companion tool I have been developing to manage highlights, promote more effortful active reading habits and improve my reading retention. I think nowadays it is good enough to be possibly for other people than just myself. It consists of a web server and a Koreader plugin.

## Checklist

Please confirm the following before submitting:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] The project is publicly accessible with a working link
- [x] The project has a README with installation instructions
- [x] It is compatible with a recent version of KOReader (or the compatible version is noted in my entry)
- [x] My entry follows the correct format: `- [name](url) - One-sentence description.`
- [x] I placed the entry in the most appropriate existing category
- [x] The description starts with a capital letter and ends with a period
- [x] I am not adding a duplicate of an existing entry

## Self-promotion disclosure

- [x] I am the author or maintainer of the project I'm adding *(if yes, that's fine — just check the box)*

## Additional context
- [Documentation](https://crossbill-app.github.io/crossbill-web/)
- [Link to the Github organization which has plugin repositories etc.](https://github.com/Crossbill-App)
