### PR TITLE
Add Witbound to Sync & File Transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
 - [AnnotationSync.koplugin](https://github.com/dani84bs/AnnotationSync.koplugin) - Keep annotations in sync between devices with cloud-based storage. ⭐ 69+
 - [grimmory](https://github.com/grimmory-tools/grimmory) - Self-Hosted app to manage library, edit metadata, OPDS server, custom progress sync
 server and more. ⭐ 3,6K+
+- [Witbound](https://witbound.app) - Phone read-along app (iOS/Android) that pairs an ebook with its audiobook word by word and syncs reading position with KOReader via KOSync, including self-hosted sync servers.
 
 ---
 


### PR DESCRIPTION
Adds Witbound under Sync & File Transfer. It speaks the KOSync protocol, so listening progress on a phone opens the epub at the right page on any KOReader device, and self-hosted sync servers work too.

Disclosure: I'm the developer. It's a paid app (closed source), so feel free to reject if that doesn't fit the list's spirit — no hard feelings.