### PR TITLE
Add Card Station to Games & Entertainment

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ server and more. ⭐ 3,6K+
 
 *Because sometimes you just need a break.*
 
+- [♤♡ Card Station ♧♢](https://github.com/alfajrd/cardstation.koplugin) - One-stop card games for solo play, two players on the same device, or against the computer — FreeCell, Briscola, Scopa, Crazy Eights and more to come.
 - [koreader/contrib: sudoku](https://github.com/koreader/contrib) - Sudoku game available in the official contrib collection.
 - [koreader/contrib: crosswords](https://github.com/koreader/contrib) - Crossword puzzle game in the contrib collection.
 - [koreader/contrib: word-search](https://github.com/koreader/contrib) - Word search puzzle in the contrib collection.


### PR DESCRIPTION
Adds [Card Station](https://github.com/alfajrd/cardstation.koplugin) to **Games & Entertainment**.

Card games for KOReader: solitaire on your own, games against the computer, and real two-player games on a single device — you pass it back and forth and a full-screen curtain makes sure nobody sees the other hand.

Ten games so far: FreeCell, War, Briscola, Scopa, Crazy Eights and Conquian, with the last four also playable against the computer. Klondike, Pyramid, TriPeaks, Golf, Yukon and Spider are on the way.

**Disclosure: I'm the author.** CONTRIBUTING says self-promotion is fine if disclosed, so — disclosed.

Against the checklist:

- **Publicly accessible** — https://github.com/alfajrd/cardstation.koplugin
- **README with description and install instructions** — yes, including the plugin-store route and the by-hand one
- **Works with a recent KOReader** — tested on a Kindle Paperwhite 11 running v2025.10. Pure Lua, no compiled code
- **Canonical source, not a mirror or fork** — yes. It vendors the card renderer from [solitaire.koplugin](https://github.com/Lalocaballero/solitaire.koplugin) under MIT with attribution in THIRD-PARTY.md, but it is a separate project with different scope, not a fork
- **Not abandoned** — [v1.0.0](https://github.com/alfajrd/cardstation.koplugin/releases/tag/v1.0.0) released this week

Two notes on placement and wording, both easy to change:

**Alphabetical, without reordering you.** The section's existing entries aren't in alphabetical order. CONTRIBUTING asks for alphabetical, so I put this where it belongs among them (C before K before S) and left your lines untouched, to keep the diff to one line. Happy to sort the whole section instead if you'd prefer.

**The suit glyphs are the plugin's actual name** — that's how it appears in KOReader's Tools menu, so it seemed more useful than a plain string for someone trying to find it on their device. If you'd rather the list stayed plain text, say the word and I'll make it "Card Station".

I left the star count off — the repo is new enough that a number would be noise.
